### PR TITLE
Update collab days schedule for week 2

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -163,6 +163,28 @@ Work together on a small project in quick, dirty and fun way
 - Thursday 10:00 - 17:00
 - Friday 10:00 - 17:00
 
+## Thursday (approximate) {.smaller}
+
+10:00 - 11:15: Intro to collaboration, getting started
+11:30 - 13:00: Git course (part 1) / collaboration
+
+14:00 - 15:30: Git course (part 2) / collaboration
+15:30 - 15:45: Spike sorting with SpikeInterface (Chris Halcrow) / collaboration
+15:45 - 17:00: collaboration
+
+17:00 Trusted by design: set up your research software for community adoption (Niko Sirmpilatze)
+
+17:45 Walk to Primrose Hill
+
+## Friday (approximate)
+
+Collaboration 10:00-16:00
+
+11:00 Napari-GUI for manual tracklets refinement (Anna Teruel) / collaboration
+14:00: A high-level introduction to whole-brain image analysis with BrainGlobe (Alessandro Felder) / collaboration
+
+16:00 Lightning talks
+
 ## Goal
 
 Enable knowledge exchange through hands-on work

--- a/index.qmd
+++ b/index.qmd
@@ -218,7 +218,7 @@ Things will go wrong – that’s OK!
 * You have a very short amount of time!
 * Focus on minimum viable "product"
 
-Report back in short lightning presentations at 4 PM [(joint slide-deck)](https://docs.google.com/presentation/d/1-4tv1ZKLjbLAY7IUUaeSmc6_KXqrsDXM9DAFLH8UqiA/edit?usp=sharing)
+Report back in short lightning presentations at 4 PM [(joint slide-deck)](https://docs.google.com/presentation/d/1_nT-tYBanzLO-Bhi1Dy2DwIdgcyR-Gjej4ZMoD4lGko/edit?usp=sharing)
 
 * What you did
 * What you learnt

--- a/index.qmd
+++ b/index.qmd
@@ -175,6 +175,8 @@ Work together on a small project in quick, dirty and fun way
 
 15:45 - 17:00: collaboration
 
+17:45 Running social: meet Wolf outside SWC in running gear.
+
 ## Friday (approximate)
 
 Collaboration 10:00-16:00

--- a/index.qmd
+++ b/index.qmd
@@ -166,24 +166,26 @@ Work together on a small project in quick, dirty and fun way
 ## Thursday (approximate) {.smaller}
 
 10:00 - 11:15: Intro to collaboration, getting started
+
 11:30 - 13:00: Git course (part 1) / collaboration
 
 14:00 - 15:30: Git course (part 2) / collaboration
-15:30 - 15:45: Spike sorting with SpikeInterface (Chris Halcrow) / collaboration
+
+15:30 - 15:45: Data management with datashuttle (Joe Ziminski) / collaboration
+
 15:45 - 17:00: collaboration
-
-17:00 Trusted by design: set up your research software for community adoption (Niko Sirmpilatze)
-
-17:45 Walk to Primrose Hill
 
 ## Friday (approximate)
 
 Collaboration 10:00-16:00
 
-11:00 Napari-GUI for manual tracklets refinement (Anna Teruel) / collaboration
-14:00: A high-level introduction to whole-brain image analysis with BrainGlobe (Alessandro Felder) / collaboration
+11:00 A high-level introduction to whole-brain image analysis with BrainGlobe (Alessandro Felder); Adapting cellfinder to single-channel and 2.5-D data (Soumya Snigdha Kundu)
+
+14:00 QUINT workflow (Harry Carey)
 
 16:00 Lightning talks
+
+17:45 Walk to Primrose Hill
 
 ## Goal
 
@@ -240,7 +242,7 @@ Things will go wrong – that’s OK!
 * You have a very short amount of time!
 * Focus on minimum viable "product"
 
-Report back in short lightning presentations at 4 PM [(joint slide-deck)](https://docs.google.com/presentation/d/1_nT-tYBanzLO-Bhi1Dy2DwIdgcyR-Gjej4ZMoD4lGko/edit?usp=sharing)
+Report back in short lightning presentations at 4 PM [(joint slide-deck)](https://docs.google.com/presentation/d/1bVvpB7u46DEUsfPD5V6A08xU_hmRg7d9WYDDPKsDHhk/edit?usp=sharing)
 
 * What you did
 * What you learnt


### PR DESCRIPTION
This PR:

- updates the collab day schedule with walk/run socials and week 2 socials
- links to a fresh set of google slides
- adds whitespace so schedule displays slightly better

We can still change if we decide to move some satellite talks or git teaching to Monday, but this reflects Plan A, I think.